### PR TITLE
Fix InvalidOperationException when calling VisualAncestorsAndSelf() o…

### DIFF
--- a/ICSharpCode.AvalonEdit/Utils/ExtensionMethods.cs
+++ b/ICSharpCode.AvalonEdit/Utils/ExtensionMethods.cs
@@ -213,7 +213,15 @@ namespace ICSharpCode.AvalonEdit.Utils
 		{
 			while (obj != null) {
 				yield return obj;
-				obj = VisualTreeHelper.GetParent(obj);
+				if (obj is Visual || obj is System.Windows.Media.Media3D.Visual3D) {
+					obj = VisualTreeHelper.GetParent(obj);
+				} else if (obj is FrameworkContentElement) {
+					// When called with a non-visual such as a TextElement, walk up the
+					// logical tree instead.
+					obj = ((FrameworkContentElement)obj).Parent;
+				} else {
+					break;
+				}
 			}
 		}
 		


### PR DESCRIPTION
…n a TextElement.

This could happen when double-clicking on a TextElement within ICompletionData.Content.